### PR TITLE
fix: open_clip package validation

### DIFF
--- a/mteb/models/openclip_models.py
+++ b/mteb/models/openclip_models.py
@@ -17,7 +17,7 @@ def openclip_loader(**kwargs):
     model_name = kwargs.get("model_name", "CLIP-ViT")
     requires_package(
         openclip_loader,
-        "open_clip_torch",
+        "open_clip",
         model_name,
         "pip install 'mteb[open_clip_torch]'",
     )


### PR DESCRIPTION
This pull request updates the dependency check in the `openclip_loader` function to reference the correct package name for OpenCLIP. This ensures that the loader checks for the presence of `open_clip` instead of the previously used `open_clip_torch`. No other changes are included.