### PR TITLE
Update dataset for KoVidoreOfficeRetrieval

### DIFF
--- a/mteb/benchmarks/benchmarks.py
+++ b/mteb/benchmarks/benchmarks.py
@@ -2003,13 +2003,14 @@ VIDORE_V2 = Benchmark(
 """,
 )
 
-KoVIDORE = VIDORE_V2 = Benchmark(
+KoVIDORE = Benchmark(
     name="KoViDoRe",
     tasks=get_tasks(
         tasks=[
             "KoVidoreMIRRetrieval",
             "KoVidoreVQARetrieval",
             "KoVidoreSlideRetrieval",
+            "KoVidoreOfficeRetrieval",
         ],
     ),
     description="Retrieve associated pages according to questions.",

--- a/mteb/tasks/Image/Any2AnyRetrieval/multilingual/Vidore2BenchRetrieval.py
+++ b/mteb/tasks/Image/Any2AnyRetrieval/multilingual/Vidore2BenchRetrieval.py
@@ -507,3 +507,60 @@ class KoVidoreSlideRetrieval(AbsTaskAny2AnyRetrieval):
         )
 
         self.data_loaded = True
+
+class KoVidoreOfficeRetrieval(AbsTaskAny2AnyRetrieval):
+    metadata = TaskMetadata(
+        name="KoVidoreOfficeRetrieval",
+        description="Retrieve associated pages according to questions.",
+        reference="https://arxiv.org/pdf/2407.01449",
+        dataset={
+            "path": "whybe-choi/kovidore-office-v0.1-beir-subsampled",
+            "revision": "7553ebdd0e1df4ad6b78f1cb564277e9bafed727",
+        },
+        type="DocumentUnderstanding",
+        category="t2i",
+        eval_splits=["test"],
+        eval_langs=["kor-Hang"],
+        main_score="ndcg_at_5",
+        date=("2025-01-01", "2025-03-01"),
+        domains=["Academic"],
+        task_subtypes=["Image Text Retrieval"],
+        license="mit",
+        annotations_creators="derived",
+        dialect=[],
+        modalities=["text", "image"],
+        sample_creation="found",
+        bibtex_citation=r"""
+@article{mace2025vidorev2, # TODO: update this bibtex
+  author = {Macé, Quentin and Loison António and Faysse, Manuel},
+  journal = {arXiv preprint arXiv:2505.17166},
+  title = {ViDoRe Benchmark V2: Raising the Bar for Visual Retrieval},
+  year = {2025},
+}
+""",
+        prompt={"query": "Find a screenshot that relevant to the user's question."}, # TODO: Is this prompt correct?
+        descriptive_stats={ # TODO: Update this stats
+            "n_samples": None,
+            "avg_character_length": {
+                "test": {
+                    "average_document_length": 1.0,
+                    "num_documents": 27,
+                    "num_queries": 640,
+                    "average_relevant_docs_per_query": 1.0,
+                }
+            },
+        },
+    )
+
+    def load_data(self, **kwargs):
+        if self.data_loaded:
+            return
+
+        self.corpus, self.queries, self.relevant_docs = _load_data(
+            path=self.metadata_dict["dataset"]["path"],
+            splits=self.metadata_dict["eval_splits"],
+            cache_dir=kwargs.get("cache_dir", None),
+            revision=self.metadata_dict["dataset"]["revision"],
+        )
+
+        self.data_loaded = True


### PR DESCRIPTION
@whybe-choi

This pull request adds a new retrieval task for the KoViDoRe benchmark and updates its configuration to include the new task. The main focus is the introduction of the `KoVidoreOfficeRetrieval` task, which expands the benchmark's coverage.

**Benchmark configuration update:**

* Added `KoVidoreOfficeRetrieval` to the list of tasks in the KoViDoRe benchmark definition in `benchmarks.py`, making it available for evaluation.

**New retrieval task implementation:**

* Introduced the `KoVidoreOfficeRetrieval` class in `Vidore2BenchRetrieval.py`, including its metadata, dataset reference, evaluation splits, modalities, and descriptive statistics. This enables document understanding and image-text retrieval for office screenshots in Korean.If you add a model or a dataset, please add the corresponding checklist:

* [dataset checklist](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#submit-a-pr)
* [model checklist](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_model.md#submitting-your-model-as-a-pr)
